### PR TITLE
Check underlying intent as well as intent selector

### DIFF
--- a/java/src/com/android/intentresolver/IntentForwarderActivity.java
+++ b/java/src/com/android/intentresolver/IntentForwarderActivity.java
@@ -312,30 +312,44 @@ public class IntentForwarderActivity extends Activity  {
      * forwarding if it can be forwarded, {@code null} otherwise.
      */
     public static Intent canForward(Intent incomingIntent, int sourceUserId, int targetUserId,
-            IPackageManager packageManager, ContentResolver contentResolver)  {
+            IPackageManager packageManager, ContentResolver contentResolver) {
         Intent forwardIntent = new Intent(incomingIntent);
         forwardIntent.addFlags(
                 Intent.FLAG_ACTIVITY_FORWARD_RESULT | Intent.FLAG_ACTIVITY_PREVIOUS_IS_TOP);
         sanitizeIntent(forwardIntent);
 
-        Intent intentToCheck = forwardIntent;
-        if (Intent.ACTION_CHOOSER.equals(forwardIntent.getAction())) {
+        if (!canForwardInner(forwardIntent, sourceUserId, targetUserId, packageManager,
+                contentResolver)) {
             return null;
         }
+
         if (forwardIntent.getSelector() != null) {
-            intentToCheck = forwardIntent.getSelector();
+            sanitizeIntent(forwardIntent.getSelector());
+
+            if (!canForwardInner(forwardIntent.getSelector(), sourceUserId, targetUserId,
+                    packageManager, contentResolver)) {
+                return null;
+            }
         }
-        String resolvedType = intentToCheck.resolveTypeIfNeeded(contentResolver);
-        sanitizeIntent(intentToCheck);
+        return forwardIntent;
+    }
+
+    private static boolean canForwardInner(Intent intent, int sourceUserId, int targetUserId,
+            IPackageManager packageManager, ContentResolver contentResolver) {
+        if (Intent.ACTION_CHOOSER.equals(intent.getAction())) {
+            return false;
+        }
+
+        String resolvedType = intent.resolveTypeIfNeeded(contentResolver);
         try {
             if (packageManager.canForwardTo(
-                    intentToCheck, resolvedType, sourceUserId, targetUserId)) {
-                return forwardIntent;
+                    intent, resolvedType, sourceUserId, targetUserId)) {
+                return true;
             }
         } catch (RemoteException e) {
             Slog.e(TAG, "PackageManagerService is dead?");
         }
-        return null;
+        return false;
     }
 
     /**


### PR DESCRIPTION
When checking if an intent can be forwarded across profiles, the selector action is checked rather than the intent itself. This means badIntents can be spoofed with a different selector and launched across profiles.

Bug: 376674080
Test: manually tested
Flag: EXEMPT bugfix
(cherry picked from https://googleplex-android-review.googlesource.com/q/commit:85ef51a7a91de0e51dd65ce5f09badcd96835817) (cherry picked from https://googleplex-android-review.googlesource.com/q/commit:d2eb1140ed9538f9a8b02f624740c685987bdbac) Merged-In: I744d0d7f89e35665405a14a814d4e0861082a106 Change-Id: I744d0d7f89e35665405a14a814d4e0861082a106